### PR TITLE
Initial build 0.5.2

### DIFF
--- a/recipe/fix-broken-file-ref.patch
+++ b/recipe/fix-broken-file-ref.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/b/setup.py
+index 1e8bc06..d529a24 100644
+--- a/setup.py
++++ b/setup.py
+@@ -13,7 +13,7 @@ from setuptools import setup, find_packages  # noqa: H301
+ 
+ from pathlib import Path
+ this_directory = Path(__file__).parent
+-long_description = (this_directory / "RELEASE.md").read_text()
++long_description = (this_directory / "README.md").read_text()
+ 
+ NAME = "whylabs-client"
+ VERSION = "0.5.1"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - patch  # [win]
+    - patch  # [not win]
     - m2-patch  # [win]
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "0.5.1" %}
+{% set name = "whylabs-client" %}
+{% set sha256 = "f7aacfab7d176812c2eb4cdeb8c52521eed0d30bc2a0836399798197a513cf04" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    # setup.py refers to missing release.md
+    - fix-broken-file-ref.patch
+
+build:
+  number: 0
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -v
+
+requirements:
+  build:
+    - patch  # [win]
+    - m2-patch  # [win]
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - urllib3 >=1.25.3
+    - python-dateutil
+
+test:
+  imports:
+    - whylabs_client
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://whylabs.ai
+  license: Apache-2.0
+  license_family: Apache
+  summary: Public Python client for WhyLabs API
+  description: WhyLabs API that enables end-to-end AI observability
+  dev_url: https://github.com/whylabs/whylabs-client-python
+  doc_url: https://docs.whylabs.ai

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.5.1" %}
+{% set version = "0.5.2" %}
 {% set name = "whylabs-client" %}
-{% set sha256 = "f7aacfab7d176812c2eb4cdeb8c52521eed0d30bc2a0836399798197a513cf04" %}
+{% set sha256 = "b7e7e78cc9524718d927954b06f95f52a7a3cca322bd4a0dc90ae8afc8164dcf" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,4 +47,4 @@ about:
   summary: Public Python client for WhyLabs API
   description: WhyLabs API that enables end-to-end AI observability
   dev_url: https://github.com/whylabs/whylabs-client-python
-  doc_url: https://docs.whylabs.ai
+  doc_url: https://docs.whylabs.ai/docs


### PR DESCRIPTION
[Upstream repo (v0.4.6)](https://github.com/whylabs/whylabs-client-python)
[Jira](https://anaconda.atlassian.net/browse/PKG-2385)

whylabs-client -> whylogs

- No license file present, and I can't find a url to reference in the documentation, but PKG-INFO states that the license is Apache 2.0. PKG-INFO is present in the package source from Pypi, but not the Github repository.
- Added a patch to fix a reference to a non-existent file in setup.py.